### PR TITLE
removed join logic

### DIFF
--- a/flow_post_lda.scala
+++ b/flow_post_lda.scala
@@ -59,17 +59,39 @@ var ipkt_cuts : Array[Double] = cuts_input.split(",")(1).split(" ").map(_.toDoub
 var time_cuts : Array[Double] = cuts_input.split(",")(2).split(" ").map(_.toDouble)
 
 //-----------------------------
+println("loading machine learning results")
+val topics_lines = sc.textFile(topic_mix_file)
+//print(topics_lines)
+val words_lines = sc.textFile(pword_file)
+//print(words_lines)
 
+val l_topics = topics_lines.map(line => {
+    val ip = line.split(",")(0)
+    val text = line.split(",")(1)
+    val text_no_quote = text.replaceAll("\"", "").split(" ").map(v => v.toDouble)
+    (ip,text_no_quote)
+    }).map(elem => elem._1 -> elem._2).collectAsMap()
+
+val topics = sc.broadcast(l_topics)
+
+val l_words = words_lines.map(line => {
+    val word = line.split(",")(0)
+    val text = line.split(",")(1)
+    val text_no_quote = text.replaceAll("\"", "").split(" ").map(v => v.toDouble)
+    (word, text_no_quote)
+    }).map(elem => elem._1 -> elem._2).collectAsMap()
+
+val words = sc.broadcast(l_words)
+
+println("loading data")
 val rawdata = sc.textFile(file)
-//Array(tr, try, trm, trd, trh, trm, trs, td, sa, da, sp, dp, pr, flg, fwd, stos, ipkt, ibyt, opkt, obyt, in, out, sas, das, dtos, dir, ra)
 //2015-04-12 00:01:06,2015,4,12,0,1,6,1.340,10.0.121.115,192.168.1.33,80,54048,TCP,.AP.SF,0,0,9,5084,0,0,2,3,0,0,0,0,10.219.32.250
 
 val datanoheader = removeHeader(rawdata)
-val sample = datanoheader.sample(false, .0001, 12345)
-//val datagood = datanoheader.filter(line => line.split(",").length == 27)
 val datagood = sample.filter(line => line.split(",").length == 27)
-val databad = datanoheader.filter(line => line.split(",").length != 27)
-//var s1 = datagood.first.trim.split(",")
+//val databad = datanoheader.filter(line => line.split(",").length != 27)
+
+//Array(tr, try, trm, trd, trh, trm, trs, td, sa, da, sp, dp, pr, flg, fwd, stos, ipkt, ibyt, opkt, obyt, in, out, sas, das, dtos, dir, ra)
 
 def add_time(row: Array[String]) = {
     val num_time = row(4).toDouble + row(5).toDouble/60 + row(6).toDouble/3600
@@ -152,139 +174,29 @@ def adjust_port(row: Array[String]) = {
 val data_with_words = binned_data.map(row => adjust_port(row))
 
 
+val src_scored = data.map(row => {
+	val topic_mix_1 = topics.value.getOrElse(row(8),Array(0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1) ).asInstanceOf[Array[Double]]
+	val word_prob_1 = words.value.getOrElse(row(33),Array(0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1) ).asInstanceOf[Array[Double]]
+	val topic_mix_2 = topics.value.getOrElse(row(9),Array(0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1) ).asInstanceOf[Array[Double]]
+	val word_prob_2 = words.value.getOrElse(row(44),Array(0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1,0.1) ).asInstanceOf[Array[Double]]
+        var src_score = 0.0 
+        var dest_score = 0.0 
+	for ( i <- 0 to 19) {
+		 src_score += topic_mix_1(i) * word_prob_1(i)
+		 dest_score += topic_mix_2(i) * word_prob_2(i)
+      	}
+	(src_score, dest_score, row :+ src_score :+ dest_score)
+	})
 
-val source = data_with_words.map(row => (row(8), row) )
-val dest = data_with_words.map(row => (row(9), row) )
-
-val topics_lines = sc.textFile(topic_mix_file)
-//print(topics_lines)
-val words_lines = sc.textFile(pword_file)
-//print(words_lines)
-
-
-val topics = topics_lines.map(line => {
-    val ip = line.split(",")(0)
-    val text = line.split(",")(1)
-    val text_no_quote = text.replaceAll("\"", "")
-    (ip, text_no_quote.split(" "))
-    })
-
-
-//topics.take(10)
-
-//this is an inner join, so we only get the ip's that were sources
-val src_top = source.join(topics)
-//src_top.take(10)
-
-val src_top_w = src_top.map( row => {
-    val data = row._2._1
-    val topic_mix = row._2._2
-    (data(33), (data, topic_mix))
-    })
-
-val words = words_lines.map(line => {
-    val word = line.split(",")(0)
-    val text = line.split(",")(1)
-    val text_no_quote = text.replaceAll("\"", "")
-    (word, text_no_quote.split(" "))
-    })
-
-/**
-val words = words_lines.map(line => {
-    val word = line.split("\"")(1).replaceAll(",", "_")
-    val letters = word.split("_")
-    val word_adj = {
-        var f : Array[String] = Array() 
-        for (letter <- letters){
-            if (letter != "-1"){f = f :+ letter + ".0"}
-        }
-        f.mkString("_")
-    }
-    val text = line.split("\"")(3)
-    (word_adj, text.split(" "))
-    })
-*/
-
-val src_top_word = src_top_w.join(words)
-
-
-
-def wtonum(n: String) = {
-    val splits = n.split("e")
-    if (splits.length < 2 & splits(0).contains("e") ) { "0"
-    }else if (splits.length < 2 & splits(0).toDouble < 1){splits(0)
-    }else if (splits.length < 2){"0"
-    }else if (splits.length == 2 & (splits(1) == "0" | splits(1) == "-" | splits(1) == "-0") ){"0"
-    }else splits(0)+"e"+splits(1)
-}
-
-
-val src_scored = src_top_word.map(row => {
-    val data = row._2._1._1
-    val topic_mix_orig = row._2._1._2
-    val topic_mix = topic_mix_orig.map(n => wtonum(n) )
-    val wordprob_orig = row._2._2
-    val wordprob = wordprob_orig.map(n => wtonum(n) )
-    val src_score = (topic_mix zip wordprob).map(elem => elem._1.toDouble*elem._2.toDouble).reduce(_+_)
-    (src_score, data :+ src_score.toString)
-    })
 
 //src_scored.take(10)
 
-//Now for destination:
-val dest_top = dest.join(topics)
 
-val dest_top_w = dest_top.map( row => {
-    val data = row._2._1
-    val topic_mix = row._2._2
-    (data(33), (data, topic_mix))
-    })
+var scored = src_scored.filter(elem => min(elem._1,elem._2) < threshold).sortByKey().map( row => row._3.mkString(",") )
 
-val dest_top_word = dest_top_w.join(words)
-
-val dest_scored = dest_top_word.map(row => {
-    val data = row._2._1._1
-    val topic_mix_orig = row._2._1._2
-    val topic_mix = topic_mix_orig.map(n => wtonum(n) )
-    val wordprob_orig = row._2._2
-    val wordprob = wordprob_orig.map(n => wtonum(n) )
-    val dest_score = (topic_mix zip wordprob).map(elem => elem._1.toDouble*elem._2.toDouble).reduce(_+_)
-    (dest_score, data :+ dest_score.toString)
-    })
-
-
-//dest_scored.take(10)
-
-val scored = sc.union(src_scored, dest_scored).filter(elem => elem._1 < threshold).repartition(1).sortByKey().map( row => row._2.mkString(",") )
 scored.persist(StorageLevel.MEMORY_AND_DISK)
 scored.saveAsTextFile(scored_output_file)
 
-
-
-
-
-
-
-
-
-
-
-//words.take(10)
-
-//val topicsBroadcast = sc.broadcast(topics.collectAsMap())
-
-//val rdd1 = sc.parallelize(Seq((1, "A"), (2, "B"), (3, "C")))
-//val rdd2 = sc.parallelize(Seq(((1, "Z"), 111), ((1, "ZZ"), 111), ((2, "Y"), 222), ((3, "X"), 333)))
-/**
-val rdd1Broadcast = sc.broadcast(rdd1.collectAsMap())
-val joined = rdd2.mapPartitions({ iter =>
-  val m = rdd1Broadcast.value
-  for {
-    ((t, w), u) <- iter
-    if m.contains(t)
-  } yield ((t, w), (u, m.get(t).get))
-}, preservesPartitioning = true)
-*/
 
 System.exit(0)
 


### PR DESCRIPTION
Address the approach/problem described in #1
- debugging statements for data load removed
- removed wtonum function - no longer needed
- doc and word results are loaded as maps then turned into broadcast variables
- model results are now double arrays instead of strings
- multiple joins are replaced by map lookups, and these all occur in one statement
- removed the sc.union step as it is no longer necessary
- removed some unused code at end of sciprt
