### PR TITLE
issue_25_lda_processcount

### DIFF
--- a/ml_ops.sh
+++ b/ml_ops.sh
@@ -58,7 +58,8 @@ do
 done
 sleep 2
 cd ${LDAPATH}
-time mpiexec -n 20 -f machinefile ./lda est 2.5 20 settings.txt ../${FDATE}/model.dat random ../${FDATE}
+PROCESS_COUNT = 20
+time mpiexec -n ${PROCESS_COUNT} -f machinefile ./lda est 2.5 20 settings.txt ${PROCESS_COUNT} ../${FDATE}/model.dat random ../${FDATE}
 sleep 10
 
 cd ${LUSER}/ml


### PR DESCRIPTION
Changed ml_ops.sh to use the new CLI parameters for lda, per:

usage: lda est [alpha] [k] [settings] [#processes] [data] [random/seeded/*] [output directory]
