### PR TITLE
reduced required arguments for ml_ops.sh

### DIFF
--- a/ml_ops.sh
+++ b/ml_ops.sh
@@ -8,6 +8,14 @@ YR=${FDATE:0:4}
 MH=${FDATE:4:2}
 DY=${FDATE:6:2}
 
+# checking for required arguments
+if [[ "${#FDATE}" != "8" || -z "${DSOURCE}" ]]; then
+    echo "ml_ops.sh syntax error"
+    echo "Please run ml_ops.sh again with the correct syntax:"
+    echo "./ml_ops.sh 19700101 flow"
+    exit
+fi
+
 # intermediate ML results go in hive directory
 DFOLDER='hive'
 DUPFACTOR=1000

--- a/ml_ops.sh
+++ b/ml_ops.sh
@@ -12,7 +12,10 @@ DY=${FDATE:6:2}
 if [[ "${#FDATE}" != "8" || -z "${DSOURCE}" ]]; then
     echo "ml_ops.sh syntax error"
     echo "Please run ml_ops.sh again with the correct syntax:"
-    echo "./ml_ops.sh 19700101 flow"
+    echo "./ml_ops.sh YYYYMMDD TYPE [TOL]"
+    echo "for example:"
+    echo "./ml_ops.sh 20160122 dns 1e-6"
+    echo "./ml_ops.sh 20160122 flow"
     exit
 fi
 

--- a/ml_ops.sh
+++ b/ml_ops.sh
@@ -1,13 +1,12 @@
 #!/bin/bash
 
 # read in variables (except for date) from etc/.conf file
-
 FDATE=$1
-YR=$2
-MH=$3
-DY=$4
-DSOURCE=$5
-TOL=$6
+DSOURCE=$2
+TOL=$3
+YR=${FDATE:0:4}
+MH=${FDATE:4:2}
+DY=${FDATE:6:2}
 
 # intermediate ML results go in hive directory
 DFOLDER='hive'


### PR DESCRIPTION
when running ml_ops.sh the user needs to provide x arguments,
example: `ml_ops.sh 20170130 2017 01 30 flow`

by using bash substring expansion we can reduce the required arguments,
example: `ml_ops.sh 20170130 flow`
