### PR TITLE
fix ml_ops.sh rm command, add verbose flag to rsync

### DIFF
--- a/install_ml.sh
+++ b/install_ml.sh
@@ -7,7 +7,7 @@ source /etc/duxbay.conf
 for d in "${NODES[@]}" 
 do
     # exclude the hidden files so we don't slam around VCS data...
-    rsync -a --exclude='.*' . $d:${LUSER}/ml
+    rsync -v -a --exclude='.*' . $d:${LUSER}/ml
 	#scp -r ${LUSER}/ml $d:${LUSER}/.    
 done
 

--- a/ml_ops.sh
+++ b/ml_ops.sh
@@ -9,6 +9,9 @@ DY=$4
 DSOURCE=$5
 TOL=$6
 
+# number of total processes for mpi
+PROCESS_COUNT=20
+
 # intermediate ML results go in hive directory
 DFOLDER='hive'
 DUPFACTOR=1000
@@ -34,12 +37,10 @@ hadoop fs -rm -R ${HPATH}/lda_word_counts
 # move TDM to local file system
 # do we have to do a mkdir here?
 mkdir -p ${LPATH}
-rm -f ${LPATH}/*.{dat, beta, other, pkl} # protect the flow_scores.csv file
+rm -f ${LPATH}/*.{dat,beta,gamma,other,pkl} # protect the flow_scores.csv file
 
 #kinit -kt /etc/security/keytabs/smokeuser.headless.keytab <user-id>
 time spark-shell --master yarn-client --executor-memory  ${SPK_EXEC_MEM}  --driver-memory 2g --num-executors ${SPK_EXEC} --executor-cores 1 --conf spark.shuffle.io.preferDirectBufs=false --conf shuffle.service.enabled=true --conf spark.driver.maxResultSize="2g"  -i scala ${DSOURCE}_pre_lda.scala
-
-
 
 hadoop fs -copyToLocal  ${HPATH}/word_counts/part-* ${LPATH}/.
 cd ${LPATH}
@@ -62,7 +63,6 @@ do
 done
 sleep 2
 cd ${LDAPATH}
-PROCESS_COUNT=20
 time mpiexec -n ${PROCESS_COUNT} -f machinefile ./lda est 2.5 20 settings.txt ${PROCESS_COUNT} ../${FDATE}/model.dat random ../${FDATE}
 sleep 10
 

--- a/ml_ops.sh
+++ b/ml_ops.sh
@@ -12,6 +12,10 @@ TOL=$6
 # number of total processes for mpi
 PROCESS_COUNT=20
 
+##do not edit##
+TOPIC_COUNT=20
+###############
+
 # intermediate ML results go in hive directory
 DFOLDER='hive'
 DUPFACTOR=1000
@@ -63,7 +67,7 @@ do
 done
 sleep 2
 cd ${LDAPATH}
-time mpiexec -n ${PROCESS_COUNT} -f machinefile ./lda est 2.5 20 settings.txt ${PROCESS_COUNT} ../${FDATE}/model.dat random ../${FDATE}
+time mpiexec -n ${PROCESS_COUNT} -f machinefile ./lda est 2.5 ${TOPIC_COUNT} settings.txt ${PROCESS_COUNT} ../${FDATE}/model.dat random ../${FDATE}
 sleep 10
 
 cd ${LUSER}/ml


### PR DESCRIPTION
relating to Open-Network-Insight/open-network-insight#68

3 changes made,
1. ml_ops.sh error in brace expansion on rm command, removed spaces and added gamma file
2. ml_ops.sh process_count variable should be near the top of the file for easy editing.
3. install_ml.sh has no output when run, added -v flag to rsync command so that the user can see it ran correctly
