### PR TITLE
Hot fix - ml_ops.sh not using passed parameter tolerance, always using /etc/duxbay.conf

### DIFF
--- a/ml_ops.sh
+++ b/ml_ops.sh
@@ -100,7 +100,7 @@ hadoop fs -put ${LPATH}/word_results.csv ${HPATH}/.
 hadoop fs -rm -R -f ${HPATH}/word_counts
 hadoop fs -rm -R -f ${HPATH}/scored
 
-if [ $3 != '' ]; then TOL=$3 ; fi
+if [ -n "$3" ]; then TOL=$3 ; fi
 export TOL
 
 

--- a/ml_ops.sh
+++ b/ml_ops.sh
@@ -100,7 +100,7 @@ hadoop fs -put ${LPATH}/word_results.csv ${HPATH}/.
 hadoop fs -rm -R -f ${HPATH}/word_counts
 hadoop fs -rm -R -f ${HPATH}/scored
 
-if [ $6 != '' ]; then TOL=$6 ; fi
+if [ $3 != '' ]; then TOL=$3 ; fi
 export TOL
 
 


### PR DESCRIPTION
Aims to close https://github.com/Open-Network-Insight/open-network-insight/issues/72

Changed ml_ops to validate if variable $3 is empty and if not, assign the value to variable TOL.
`if [ $3 != '' ]; then TOL=$3 ; fi export TOL`
