### PR TITLE
proc_count_to_conf

### DIFF
--- a/ml_ops.sh
+++ b/ml_ops.sh
@@ -30,11 +30,6 @@ source /etc/duxbay.conf
 if [ -n "$3" ]; then TOL=$3 ; fi
 
 
-# number of total processes for MPI... EDIT THIS!
-
-PROCESS_COUNT=20
-
-
 # prepare parameters pipeline stages
 
 if [ "$DSOURCE" == "flow" ]; then


### PR DESCRIPTION
ml_ops.sh now picks up PROCESS_COUNT (the number of processes running the task in MPI) from duxbay.conf

User shold no longer have to edit the ml_ops.sh file when installing ML pipeline or reconfiguring MPI.
