### PR TITLE
Modified Flow (pre and post) to read parquet files instead of csv

### DIFF
--- a/src/main/scala/org/opennetworkinsight/FlowColumnIndex.scala
+++ b/src/main/scala/org/opennetworkinsight/FlowColumnIndex.scala
@@ -1,20 +1,20 @@
 package org.opennetworkinsight
 
 object FlowColumnIndex extends Enumeration {
-    val HOUR = 4
-    val MINUTE = 5
-    val SECOND = 6
-    val SOURCEIP = 8
-    val DESTIP = 9
-    val SOURCEPORT = 10
-    val DESTPORT = 11
-    val IPKT = 16
-    val IBYT = 17
-    val NUMTIME = 27
-    val IBYTBIN = 28
-    val IPKTYBIN = 29
-    val TIMEBIN = 30
-    val SOURCEWORD = 33
-    val DESTWORD = 34
+    val HOUR = 0
+    val MINUTE = 1
+    val SECOND = 2
+    val SOURCEIP = 3
+    val DESTIP = 4
+    val SOURCEPORT =5
+    val DESTPORT = 6
+    val IPKT = 7
+    val IBYT = 8
+    val NUMTIME = 9
+    val IBYTBIN = 10
+    val IPKTYBIN = 11
+    val TIMEBIN = 12
+    val SOURCEWORD = 13
+    val DESTWORD = 14
   }
 

--- a/src/main/scala/org/opennetworkinsight/FlowWordCreation.scala
+++ b/src/main/scala/org/opennetworkinsight/FlowWordCreation.scala
@@ -39,8 +39,8 @@ object FlowWordCreation {
       var word_port = 111111.0
       val sip = row(FlowColumnIndex.SOURCEIP)
       val dip = row(FlowColumnIndex.DESTIP)
-      val dport = row(FlowColumnIndex.SOURCEPORT).toDouble
-      val sport = row(FlowColumnIndex.DESTPORT).toDouble
+      val dport = row(FlowColumnIndex.DESTPORT).toDouble
+      val sport = row(FlowColumnIndex.SOURCEPORT).toDouble
       val ipkt_bin = row(FlowColumnIndex.IPKTYBIN).toDouble
       val ibyt_bin = row(FlowColumnIndex.IBYTBIN).toDouble
       val time_bin = row(FlowColumnIndex.TIMEBIN).toDouble


### PR DESCRIPTION
- Modified FlowPreLDA.scala to read parquet and just the necessary columns (not the entire data set) by filtering columns with SQL spark.
- Modified FlowPostLDA.scala to read parquet, same case as avobe, no need to read all columns.
  -Modified FlowColumnIndex to match the new number of columns. The position of each column is a sequence of how they are being _selected_ and for the calculated columns, their position is given by the order they are being added.  
- Modified FlowWordCreation.scala because there was two columns switched, SOURCEPORT and DESTPORT.
