### PR TITLE
Modified LPATH to split results into each data source - ml_ops.sh

### DIFF
--- a/ml_ops.sh
+++ b/ml_ops.sh
@@ -92,7 +92,8 @@ wait
 for d in "${NODES[@]}" 
 do 
 	echo "copying $d ${LPATH} ${LUSER}"
-	scp -r ${LPATH} $d:${LUSER}/ml/.    
+	ssh $d 'mkdir '"'${LUSER}'"'/ml/'"'${DSOURCE}'"
+	scp -r ${LPATH} $d:${LUSER}/ml/${DSOURCE}/.
 done
 wait
 


### PR DESCRIPTION
LPATH was being determined by date only. Running Flow data and DNS data for the same day resulted into a file overlapping; common files like words, docs, final.gamma, final.beta. 
Having a folder for each data source we will avoid that overlapping.

Modified ml_ops.sh to match folder structure in each node. 
We need first to create data source folder under ~/ml. Added ssh command to do that. 
After that we are safe to copy the date folder into ~/ml/dns or ~/ml/flow depending on the data source.

Now LPATH looks like /home/solution-user/ml/dns/YYYYMMDD or /home/solution-user/ml/flow/YYYYMMDD.
