### PR TITLE
Added missing columns required by OA. Fixed column indexes after adding missing columns.

### DIFF
--- a/src/main/scala/org/opennetworkinsight/FlowColumnIndex.scala
+++ b/src/main/scala/org/opennetworkinsight/FlowColumnIndex.scala
@@ -14,7 +14,9 @@ object FlowColumnIndex extends Enumeration {
     val IBYTBIN = 10
     val IPKTYBIN = 11
     val TIMEBIN = 12
-    val SOURCEWORD = 13
-    val DESTWORD = 14
+    val PORTWORD = 13
+    val IPPAIR = 14
+    val SOURCEWORD = 15
+    val DESTWORD = 16
   }
 

--- a/src/main/scala/org/opennetworkinsight/FlowColumnIndex.scala
+++ b/src/main/scala/org/opennetworkinsight/FlowColumnIndex.scala
@@ -1,20 +1,20 @@
 package org.opennetworkinsight
 
 object FlowColumnIndex extends Enumeration {
-    val HOUR = 4
-    val MINUTE = 5
-    val SECOND = 6
-    val SOURCEIP = 8
-    val DESTIP = 9
-    val SOURCEPORT = 10
-    val DESTPORT = 11
-    val IPKT = 16
-    val IBYT = 17
-    val NUMTIME = 27
-    val IBYTBIN = 28
-    val IPKTYBIN = 29
-    val TIMEBIN = 30
-    val SOURCEWORD = 33
-    val DESTWORD = 34
+    val HOUR = 0
+    val MINUTE = 1
+    val SECOND = 2
+    val SOURCEIP = 3
+    val DESTIP = 4
+    val SOURCEPORT =5
+    val DESTPORT = 6
+    val IPKT = 7
+    val IBYT = 8
+    val NUMTIME = 9
+    val IBYTBIN = 10
+    val IPKTYBIN = 11
+    val TIMEBIN = 12
+    val SOURCEWORD = 13
+    val DESTWORD = 14
   }
 

--- a/src/main/scala/org/opennetworkinsight/FlowColumnIndex.scala
+++ b/src/main/scala/org/opennetworkinsight/FlowColumnIndex.scala
@@ -1,22 +1,22 @@
 package org.opennetworkinsight
 
 object FlowColumnIndex extends Enumeration {
-    val HOUR = 0
-    val MINUTE = 1
-    val SECOND = 2
-    val SOURCEIP = 3
-    val DESTIP = 4
-    val SOURCEPORT =5
-    val DESTPORT = 6
-    val IPKT = 7
-    val IBYT = 8
-    val NUMTIME = 9
-    val IBYTBIN = 10
-    val IPKTYBIN = 11
-    val TIMEBIN = 12
-    val PORTWORD = 13
-    val IPPAIR = 14
-    val SOURCEWORD = 15
-    val DESTWORD = 16
+    val HOUR = 4
+    val MINUTE = 5
+    val SECOND = 6
+    val SOURCEIP = 8
+    val DESTIP = 9
+    val SOURCEPORT = 10
+    val DESTPORT = 11
+    val IPKT = 16
+    val IBYT = 17
+    val NUMTIME = 27
+    val IBYTBIN = 28
+    val IPKTYBIN = 29
+    val TIMEBIN = 30
+    val PORTWORD = 31
+    val IPPAIR = 32
+    val SOURCEWORD = 33
+    val DESTWORD = 34
   }
 

--- a/src/main/scala/org/opennetworkinsight/FlowPostLDA.scala
+++ b/src/main/scala/org/opennetworkinsight/FlowPostLDA.scala
@@ -94,15 +94,33 @@ object FlowPostLDA {
             .filter("trhour BETWEEN 0 AND 23 AND  " +
               "trminute BETWEEN 0 AND 59 AND  " +
               "trsec BETWEEN 0 AND 59")
-            .select("trhour",
+            .select("treceived",
+              "tryear",
+              "trmonth",
+              "trday",
+              "trhour",
               "trminute",
               "trsec",
+              "tdur",
               "sip",
               "dip",
               "sport",
               "dport",
+              "proto",
+              "flag",
+              "fwd",
+              "stos",
               "ipkt",
-              "ibyt")
+              "ibyt",
+              "opkt",
+              "obyt",
+              "input",
+              "output",
+              "sas",
+              "das",
+              "dtos",
+              "dir",
+              "rip")
           flowDataFrame.map(_.mkString(","))
         }
 

--- a/src/main/scala/org/opennetworkinsight/FlowPreLDA.scala
+++ b/src/main/scala/org/opennetworkinsight/FlowPreLDA.scala
@@ -178,15 +178,33 @@ object FlowPreLDA {
               .filter("trhour BETWEEN 0 AND 23 AND  " +
                 "trminute BETWEEN 0 AND 59 AND  " +
                 "trsec BETWEEN 0 AND 59")
-              .select("trhour",
+              .select("treceived",
+                "tryear",
+                "trmonth",
+                "trday",
+                "trhour",
                 "trminute",
                 "trsec",
+                "tdur",
                 "sip",
                 "dip",
                 "sport",
                 "dport",
+                "proto",
+                "flag",
+                "fwd",
+                "stos",
                 "ipkt",
-                "ibyt")
+                "ibyt",
+                "opkt",
+                "obyt",
+                "input",
+                "output",
+                "sas",
+                "das",
+                "dtos",
+                "dir",
+                "rip")
             flowDataFrame.map(_.mkString(","))
           }
 

--- a/src/main/scala/org/opennetworkinsight/FlowWordCreation.scala
+++ b/src/main/scala/org/opennetworkinsight/FlowWordCreation.scala
@@ -39,8 +39,8 @@ object FlowWordCreation {
       var word_port = 111111.0
       val sip = row(FlowColumnIndex.SOURCEIP)
       val dip = row(FlowColumnIndex.DESTIP)
-      val dport = row(FlowColumnIndex.SOURCEPORT).toDouble
-      val sport = row(FlowColumnIndex.DESTPORT).toDouble
+      val dport = row(FlowColumnIndex.DESTPORT).toDouble
+      val sport = row(FlowColumnIndex.SOURCEPORT).toDouble
       val ipkt_bin = row(FlowColumnIndex.IPKTYBIN).toDouble
       val ibyt_bin = row(FlowColumnIndex.IBYTBIN).toDouble
       val time_bin = row(FlowColumnIndex.TIMEBIN).toDouble


### PR DESCRIPTION
After changing indexes for ML to read avro parquet data, SOURCEWORD and DESTWORD indexes were misplaced. 
I'm also including back all the columns in flow table as they are needed by Flow OA and Feedback.

Assigned the correct indexes and tested with a run of a complete day of data.

words.data, doc.dat and model.dat are looking like they are supposed to look.  
