### PR TITLE
Move ml results to hdfs

### DIFF
--- a/ml_ops.sh
+++ b/ml_ops.sh
@@ -129,12 +129,7 @@ time spark-submit --class "org.opennetworkinsight.Dispatcher" --master yarn-clie
 
 wait
 
-hdfs dfs -copyToLocal ${HDFS_SCORED_CONNECTS}/part-* ${LPATH}/.
-wait
-
+# move results to hdfs.
 cd ${LPATH}
+hadoop fs -getmerge ${HDFS_SCORED_CONNECTS}/part-* ${DSOURCE}_results.csv && hadoop fs -moveFromLocal ${DSOURCE}_results.csv  ${HDFS_SCORED_CONNECTS}/${DSOURCE}_results.csv
 
-cat part-* > ${DSOURCE}_results.csv
-rm -f part-*
-
-scp -r ${LPATH} ${UINODE}:${RPATH}


### PR DESCRIPTION
-Moving ML result to HDFS instead of OA server.

NOTE: @NathanSegerlind @rabarona I am using "hadoop fs -getmerge" and ml_ops.sh is using hdfs dfs to manage files in hdfs , is there any problem with that ?
