### PR TITLE
Topk suspicious

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,17 +126,26 @@ The Hive tables containing DNS data for oni-ml analyses have the following schem
 
 To run a suspicious connects analysis, execute the  `ml_ops.sh` script in the ml directory of the MLNODE.
 ```
-./ml_ops.sh YYYMMDD <type> <suspicion threshold>
+./ml_ops.sh YYYMMDD <type> <suspicion threshold> <max results returned>
 ```
+
 
 For example:  
 ```
-./ml_ops.sh 19731231 flow 1e-20
+./ml_ops.sh 19731231 flow 1e-20 200
 ```
-and
+
+If the max results returned argument is not provided, all results with scores below the threshold will be returned, for example:
 ```
 ./ml_ops.sh 20150101 dns 1e-4
 ```
+
+As the maximum probability of an event is 1, a threshold of 1 can be used to select a fixed number of most suspicious items regardless of their exact scores:
+```
+./ml_ops.sh 20150101 proxy 1 2000
+```
+
+
 ### oni-ml output
 
 Final results are stored in the following file on HDFS:

--- a/ml_ops.sh
+++ b/ml_ops.sh
@@ -29,6 +29,11 @@ source /etc/duxbay.conf
 
 if [ -n "$3" ]; then TOL=$3 ; fi
 
+if [ -n "$4" ]; then
+    MAXRESULTS=$4
+else
+    MAXRESULTS=-1
+fi
 
 # prepare parameters pipeline stages
 
@@ -95,10 +100,10 @@ time spark-submit --class "org.opennetworkinsight.SuspiciousConnects" --master y
   --mpicmd ${MPI_CMD}  \
   --proccount ${PROCESS_COUNT} \
   --topiccount ${TOPIC_COUNT} \
-  --dsource ${DSOURCE} \
   --nodes ${nodes} \
   --scored ${HDFS_SCORED_CONNECTS} \
-  --threshold ${TOL}
+  --threshold ${TOL} \
+  --maxresults ${MAXRESULTS}
 
 wait
 

--- a/src/main/scala/org/opennetworkinsight/SuspiciousConnectsArgumentParser.scala
+++ b/src/main/scala/org/opennetworkinsight/SuspiciousConnectsArgumentParser.scala
@@ -24,8 +24,7 @@ object SuspiciousConnectsArgumentParser {
                     nodes: String = "",
                     hdfsScoredConnect: String = "",
                     threshold: Double = 1.0d,
-                    kMostSuspicious: Int = 100,
-                    useKMostSuspicious: Boolean = false)
+                    maxResults: Int = -1)
 
   val parser: scopt.OptionParser[Config] = new scopt.OptionParser[Config]("LDA") {
 
@@ -37,7 +36,7 @@ object SuspiciousConnectsArgumentParser {
 
     opt[String]('i', "input").required().valueName("<hdfs path>").
       action((x, c) => c.copy(inputPath = x)).
-      text("HDFS path to netflow records")
+      text("HDFS path to input")
 
     opt[String]('f', "feedback").valueName("<local file>").
       action((x, c) => c.copy(scoresFile = x)).
@@ -87,15 +86,12 @@ object SuspiciousConnectsArgumentParser {
       action((x, c) => c.copy(localUser = x)).
       text("Local user path")
 
-    opt[String]('s', "dsource").required().valueName("<input param>").
-      action((x, c) => c.copy(dataSource = x)).
-      text("Data source")
 
     opt[String]('n', "nodes").required().valueName("<input param>").
       action((x, c) => c.copy(nodes = x)).
       text("Node list")
 
-    opt[String]('h', "scored").required().valueName("<hdfs path>").
+    opt[String]('s', "scored").required().valueName("<hdfs path>").
       action((x, c) => c.copy(hdfsScoredConnect = x)).
       text("HDFS path for results")
 
@@ -103,8 +99,8 @@ object SuspiciousConnectsArgumentParser {
       action((x, c) => c.copy(threshold = x)).
       text("probability threshold for declaring anomalies")
 
-    opt[Int]('k', "topmost").required().valueName("integer").
-      action((x, c) => c.copy(kMostSuspicious = x, useKMostSuspicious = true)).
+    opt[Int]('k', "maxresults").required().valueName("integer").
+      action((x, c) => c.copy(maxResults = x)).
       text("number of most suspicious connections to return")
   }
 }

--- a/src/main/scala/org/opennetworkinsight/SuspiciousConnectsArgumentParser.scala
+++ b/src/main/scala/org/opennetworkinsight/SuspiciousConnectsArgumentParser.scala
@@ -23,7 +23,9 @@ object SuspiciousConnectsArgumentParser {
                     dataSource: String = "",
                     nodes: String = "",
                     hdfsScoredConnect: String = "",
-                    threshold: Double = 1.0d)
+                    threshold: Double = 1.0d,
+                    kMostSuspicious: Int = 100,
+                    useKMostSuspicious: Boolean = false)
 
   val parser: scopt.OptionParser[Config] = new scopt.OptionParser[Config]("LDA") {
 
@@ -100,5 +102,9 @@ object SuspiciousConnectsArgumentParser {
     opt[Double]('e', "threshold").required().valueName("float64").
       action((x, c) => c.copy(threshold = x)).
       text("probability threshold for declaring anomalies")
+
+    opt[Int]('k', "topmost").required().valueName("integer").
+      action((x, c) => c.copy(kMostSuspicious = x, useKMostSuspicious = true)).
+      text("number of most suspicious connections to return")
   }
 }

--- a/src/main/scala/org/opennetworkinsight/dns/DNSPostLDA.scala
+++ b/src/main/scala/org/opennetworkinsight/dns/DNSPostLDA.scala
@@ -154,15 +154,15 @@ object DNSPostLDA {
     } else {
       topK
     }
-    class OrderByLeastScoreToTop() extends Ordering[(Double,Array[Any])] {
-      def compare(p1: (Double, Array[Any]), p2: (Double, Array[Any]))    = p2._1.compare(p1._1)
+    class DataOrdering() extends Ordering[(Double,Array[Any])] {
+      def compare(p1: (Double, Array[Any]), p2: (Double, Array[Any]))    = p1._1.compare(p2._1)
     }
 
-    implicit val ordering = new OrderByLeastScoreToTop()
+    implicit val ordering = new DataOrdering()
 
-    val top : Array[(Double,Array[Any])] = filtered.top(takeCount)
+    val top : Array[(Double,Array[Any])] = filtered.takeOrdered(takeCount)
 
-    val outputRDD = sc.parallelize(top).sortBy(_._1).map(_._2.mkString("\t"))
+    val outputRDD = sc.parallelize(top).sortBy(_._1).map(_._2.mkString(","))
 
     outputRDD.saveAsTextFile(resultsFilePath)
 

--- a/src/main/scala/org/opennetworkinsight/dns/DNSSuspiciousConnects.scala
+++ b/src/main/scala/org/opennetworkinsight/dns/DNSSuspiciousConnects.scala
@@ -17,9 +17,9 @@ object DNSSuspiciousConnects {
 
     val (documentResults, wordResults) = OniLDACWrapper.runLDA(docWordCount, config.modelFile, config.topicDocumentFile, config.topicWordFile,
       config.mpiPreparationCmd, config.mpiCmd, config.mpiProcessCount, config.mpiTopicCount, config.localPath,
-      config.ldaPath, config.localUser, config.dataSource, config.nodes)
+      config.ldaPath, config.localUser, config.analysis, config.nodes)
 
-    DNSPostLDA.dnsPostLDA(config.inputPath, config.hdfsScoredConnect, config.threshold, documentResults,
+    DNSPostLDA.dnsPostLDA(config.inputPath, config.hdfsScoredConnect, config.threshold, config.maxResults, documentResults,
       wordResults, sparkContext, sqlContext, logger)
 
     logger.info("DNS LDA completed")

--- a/src/main/scala/org/opennetworkinsight/netflow/FlowPostLDA.scala
+++ b/src/main/scala/org/opennetworkinsight/netflow/FlowPostLDA.scala
@@ -121,15 +121,15 @@ object FlowPostLDA {
       topK
     }
 
-    class OrderByLeastScoreToTop() extends Ordering[(Double,Array[Any])] {
-      def compare(p1: (Double, Array[Any]), p2: (Double, Array[Any]))    = p2._1.compare(p1._1)
+    class DataOrdering() extends Ordering[(Double,Array[Any])] {
+      def compare(p1: (Double, Array[Any]), p2: (Double, Array[Any]))    = p1._1.compare(p2._1)
     }
 
-    implicit val ordering = new OrderByLeastScoreToTop()
+    implicit val ordering = new DataOrdering()
 
-    val top : Array[(Double,Array[Any])] = filtered.top(takeCount)
+    val top : Array[(Double,Array[Any])] = filtered.takeOrdered(takeCount)
 
-    val outputRDD = sc.parallelize(top).sortBy(_._1).map(_._2.mkString("\t"))
+    val outputRDD = sc.parallelize(top).sortBy(_._1).map(_._2.mkString(","))
 
     outputRDD.saveAsTextFile(resultsFilePath)
 

--- a/src/main/scala/org/opennetworkinsight/netflow/FlowPostLDA.scala
+++ b/src/main/scala/org/opennetworkinsight/netflow/FlowPostLDA.scala
@@ -4,7 +4,7 @@ import breeze.linalg._
 import org.apache.log4j.{Logger => apacheLogger}
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.SQLContext
+import org.apache.spark.sql.{Row, SQLContext}
 import org.opennetworkinsight.utilities.Quantiles
 import org.opennetworkinsight.netflow.{FlowColumnIndex => indexOf}
 import org.slf4j.Logger
@@ -111,20 +111,27 @@ object FlowPostLDA {
 
 
 
-    val filteredSorted = src_scored.filter(elem => elem._1 < threshold).sortByKey()
+    val filtered = src_scored.filter(elem => elem._1 < threshold)
 
-    val count = filteredSorted.count
+    val count = filtered.count
 
     val takeCount  = if (topK == -1 || count < topK) {
       count.toInt
     } else {
       topK
     }
-    val scored : RDD[String] =  sc.parallelize(filteredSorted.take(takeCount).map(row => row._2.mkString("\t")))
 
-    logger.info("Persisting data")
+    class OrderByLeastScoreToTop() extends Ordering[(Double,Array[Any])] {
+      def compare(p1: (Double, Array[Any]), p2: (Double, Array[Any]))    = p2._1.compare(p1._1)
+    }
 
-    scored.saveAsTextFile(resultsFilePath)
+    implicit val ordering = new OrderByLeastScoreToTop()
+
+    val top : Array[(Double,Array[Any])] = filtered.top(takeCount)
+
+    val outputRDD = sc.parallelize(top).sortBy(_._1).map(_._2.mkString("\t"))
+
+    outputRDD.saveAsTextFile(resultsFilePath)
 
     logger.info("Flow post LDA completed")
 

--- a/src/main/scala/org/opennetworkinsight/netflow/FlowSuspiciousConnects.scala
+++ b/src/main/scala/org/opennetworkinsight/netflow/FlowSuspiciousConnects.scala
@@ -17,9 +17,9 @@ object FlowSuspiciousConnects {
 
     val (documentResults, wordResults) = OniLDACWrapper.runLDA(docWordCount, config.modelFile, config.topicDocumentFile, config.topicWordFile,
       config.mpiPreparationCmd, config.mpiCmd, config.mpiProcessCount, config.mpiTopicCount, config.localPath,
-      config.ldaPath, config.localUser,  config.dataSource, config.nodes)
+      config.ldaPath, config.localUser,  config.analysis, config.nodes)
 
-    FlowPostLDA.flowPostLDA(config.inputPath, config.hdfsScoredConnect, config.threshold, documentResults,
+    FlowPostLDA.flowPostLDA(config.inputPath, config.hdfsScoredConnect, config.threshold, config.maxResults, documentResults,
       wordResults, sparkContext, sqlContext, logger)
 
     logger.info("Flow LDA completed")

--- a/src/main/scala/org/opennetworkinsight/proxy/ProxyPostLDA.scala
+++ b/src/main/scala/org/opennetworkinsight/proxy/ProxyPostLDA.scala
@@ -66,15 +66,15 @@ object ProxyPostLDA {
 
     val scoreIndex = filteredDF.schema.fieldNames.indexOf("score")
 
-    class RowOrderByLeastScoreToTop() extends Ordering[Row] {
-      def compare(row1: Row, row2: Row) = row2.getDouble(scoreIndex).compare(row1.getDouble(scoreIndex))
+    class DataOrdering() extends Ordering[Row] {
+      def compare(row1: Row, row2: Row) = row1.getDouble(scoreIndex).compare(row2.getDouble(scoreIndex))
     }
 
-    implicit val rowOrdering = new RowOrderByLeastScoreToTop()
-    val topRows : Array[Row] = filteredDF.rdd.top(takeCount)
+    implicit val rowOrdering = new DataOrdering()
+    val topRows : Array[Row] = filteredDF.rdd.takeOrdered(takeCount)
 
-    val outRDD = sc.parallelize(topRows).sortBy(row => row.getDouble(scoreIndex))
-    outRDD.map(_.mkString("\t")).saveAsTextFile(resultsFilePath)
+    val outputRDD = sc.parallelize(topRows).sortBy(row => row.getDouble(scoreIndex))
+    outputRDD.map(_.mkString(",")).saveAsTextFile(resultsFilePath)
 
 
     logger.info("Persisting data")

--- a/src/main/scala/org/opennetworkinsight/proxy/ProxyPostLDA.scala
+++ b/src/main/scala/org/opennetworkinsight/proxy/ProxyPostLDA.scala
@@ -73,10 +73,7 @@ object ProxyPostLDA {
     implicit val rowOrdering = new RowOrderByLeastScoreToTop()
     val topRows : Array[Row] = filteredDF.rdd.top(takeCount)
 
-    val sortedRows = topRows.sortBy(row => row.getDouble(scoreIndex))
-
-
-    val outRDD = sc.parallelize(sortedRows)
+    val outRDD = sc.parallelize(topRows).sortBy(row => row.getDouble(scoreIndex))
     outRDD.map(_.mkString("\t")).saveAsTextFile(resultsFilePath)
 
 

--- a/src/main/scala/org/opennetworkinsight/proxy/ProxySuspiciousConnects.scala
+++ b/src/main/scala/org/opennetworkinsight/proxy/ProxySuspiciousConnects.scala
@@ -20,10 +20,11 @@ object ProxySuspiciousConnects {
 
     val (documentResults, wordResults) = OniLDACWrapper.runLDA(docWordCount, config.modelFile, config.topicDocumentFile, config.topicWordFile,
       config.mpiPreparationCmd, config.mpiCmd, config.mpiProcessCount, config.mpiTopicCount, config.localPath,
-      config.ldaPath, config.localUser,  config.dataSource, config.nodes)
+      config.ldaPath, config.localUser,  config.analysis, config.nodes)
 
     val topicCount  = 20
-    ProxyPostLDA.getResults(config.inputPath, config.hdfsScoredConnect, topicCount,  config.threshold, documentResults,
+    ProxyPostLDA.getResults(config.inputPath, config.hdfsScoredConnect, topicCount,  config.threshold,
+      config.maxResults, documentResults,
       wordResults, sparkContext, sqlContext, logger)
 
     logger.info("Proxy suspcicious connects completed")


### PR DESCRIPTION
This change adds a "max results" parameter as a fourth argument to ml_ops.sh that controls the maximum results to come back.

WHY:  hard coded thresholds were causing problems with smaller test datasets returning nothing because the threshold was too small, leading a trial-and-error tweaking of the threshold for certain datasets 
- it works for all suspicious connections pipelines: dns, flow, proxy
- if you just want the top k, set the threshold to 1 and set the max results to k:
  ./ml_ops.sh 20150101 flow 1 100
  will do a netflow suspicous connects analysis and return the 100 most suspicious regardless of scores
- if there are fewer than k elements that pass the threshold, all elements passing the threshold will be returned.  For example:
  ./ml_opds.sh 20150101 dns 1e-10 100 
  will return only one item if only one item has a score < 1e-10 
- if no fourth argument is provided, all items passing the threshold are returned, regardless of number
