### PR TITLE
lda_seeding_for_testing

### DIFF
--- a/src/main/scala/org/opennetworkinsight/OniLDACWrapper.scala
+++ b/src/main/scala/org/opennetworkinsight/OniLDACWrapper.scala
@@ -34,7 +34,8 @@ object OniLDACWrapper {
              ldaPath: String,
              localUser: String,
              dataSource: String,
-             nodes: String):   OniLDACOutput =  {
+             nodes: String,
+             prgSeed: Option[Long]):   OniLDACOutput =  {
 
     // Create word Map Word,Index for further usage
     val wordDictionary: Map[String, Int] = {
@@ -80,8 +81,11 @@ object OniLDACWrapper {
 
     // Execute MPI
 
+    val prgSeedString = if (prgSeed.nonEmpty) prgSeed.get.toString() else ""
+
     sys.process.Process(Seq(mpiCmd, "-n", mpiProcessCount, "-f", "machinefile", "./lda", "est", "2.5",
-      mpiTopicCount, "settings.txt", mpiProcessCount, modelFile, "random", localPath), new java.io.File(ldaPath)) #> (System.out) !!
+      mpiTopicCount, "settings.txt",  modelFile, "random", localPath, prgSeedString),
+      new java.io.File(ldaPath)) #> (System.out) !!
 
     // Read topic info per document
 

--- a/src/main/scala/org/opennetworkinsight/SuspiciousConnectsArgumentParser.scala
+++ b/src/main/scala/org/opennetworkinsight/SuspiciousConnectsArgumentParser.scala
@@ -25,7 +25,8 @@ object SuspiciousConnectsArgumentParser {
                                       hdfsScoredConnect: String = "",
                                       threshold: Double = 1.0d,
                                       maxResults: Int = -1,
-                                      outputDelimiter: String = "\t")
+                                      outputDelimiter: String = "\t",
+                                      ldaPRGSeed: Option[Long] = None)
 
   val parser: scopt.OptionParser[SuspiciousConnectsConfig] = new scopt.OptionParser[SuspiciousConnectsConfig]("LDA") {
 
@@ -107,5 +108,9 @@ object SuspiciousConnectsArgumentParser {
     opt[String]('b', "delimiter").optional().valueName("character").
       action((x, c) => c.copy(outputDelimiter = x)).
       text("number of most suspicious connections to return")
+
+    opt[String]("prgseed").optional().valueName("long").
+      action((x, c) => c.copy(ldaPRGSeed = Some(x.toLong))).
+      text("seed for the pseudorandom generator")
   }
 }

--- a/src/main/scala/org/opennetworkinsight/dns/DNSSuspiciousConnects.scala
+++ b/src/main/scala/org/opennetworkinsight/dns/DNSSuspiciousConnects.scala
@@ -18,7 +18,7 @@ object DNSSuspiciousConnects {
 
     val OniLDACOutput(documentResults, wordResults) = OniLDACWrapper.runLDA(docWordCount, config.modelFile, config.topicDocumentFile, config.topicWordFile,
       config.mpiPreparationCmd, config.mpiCmd, config.mpiProcessCount, config.mpiTopicCount, config.localPath,
-      config.ldaPath, config.localUser, config.analysis, config.nodes)
+      config.ldaPath, config.localUser, config.analysis, config.nodes, config.ldaPRGSeed)
 
     DNSPostLDA.dnsPostLDA(config.inputPath, config.hdfsScoredConnect, config.outputDelimiter, config.threshold, config.maxResults, documentResults,
       wordResults, sparkContext, sqlContext, logger)

--- a/src/main/scala/org/opennetworkinsight/netflow/FlowSuspiciousConnects.scala
+++ b/src/main/scala/org/opennetworkinsight/netflow/FlowSuspiciousConnects.scala
@@ -18,7 +18,7 @@ object FlowSuspiciousConnects {
 
     val OniLDACOutput(documentResults, wordResults) = OniLDACWrapper.runLDA(docWordCount, config.modelFile, config.topicDocumentFile, config.topicWordFile,
       config.mpiPreparationCmd, config.mpiCmd, config.mpiProcessCount, config.mpiTopicCount, config.localPath,
-      config.ldaPath, config.localUser,  config.analysis, config.nodes)
+      config.ldaPath, config.localUser,  config.analysis, config.nodes, config.ldaPRGSeed)
 
     FlowPostLDA.flowPostLDA(config.inputPath, config.hdfsScoredConnect, config.outputDelimiter, config.threshold, config.maxResults, documentResults,
       wordResults, sparkContext, sqlContext, logger)

--- a/src/main/scala/org/opennetworkinsight/netflow/FlowWordCreation.scala
+++ b/src/main/scala/org/opennetworkinsight/netflow/FlowWordCreation.scala
@@ -46,6 +46,7 @@ object FlowWordCreation {
       .rdd
       .map({ case Row(ipkt: Long) => ipkt.toDouble }))
 
+
     logger.info(ipktCuts.mkString(","))
 
     var udfBin = this.udfBin(ibytCuts)
@@ -68,9 +69,9 @@ object FlowWordCreation {
             destinationIp = row.getString(fieldNamesIndex(Schema.DestinationIP)),
             destinationPort = row.getInt(fieldNamesIndex(Schema.DestinationPort)),
             sourcePort = row.getInt(fieldNamesIndex(Schema.SourcePort)),
-            ipktBin = row.getInt(fieldNamesIndex(Schema.IPKTBin)).toDouble,
-            ibytBin = row.getInt(fieldNamesIndex(Schema.IBYTBin)).toDouble,
-            timeBin = row.getInt(fieldNamesIndex(Schema.TimeBin)).toDouble)
+            ipktBin = row.getInt(fieldNamesIndex(Schema.IPKTBin)),
+            ibytBin = row.getInt(fieldNamesIndex(Schema.IBYTBin)),
+            timeBin = row.getInt(fieldNamesIndex(Schema.TimeBin)))
       })
 
     val schemaWithWord = {
@@ -95,11 +96,11 @@ object FlowWordCreation {
                  destinationIp: String,
                  destinationPort: Int,
                  sourcePort: Int,
-                 ipktBin: Double,
-                 ibytBin: Double,
-                 timeBin: Double) = {
-    var wordPort = 111111.0
-    var portCase = 0
+                 ipktBin: Int,
+                 ibytBin: Int,
+                 timeBin: Int) = {
+    var wordPort : Int= 111111
+    var portCase : Int = 0
 
     var ipPair = destinationIp + " " + sourceIp
     if (sourceIp < destinationIp && sourceIp != 0) {

--- a/src/main/scala/org/opennetworkinsight/proxy/ProxySuspiciousConnectsModel.scala
+++ b/src/main/scala/org/opennetworkinsight/proxy/ProxySuspiciousConnectsModel.scala
@@ -128,7 +128,8 @@ object ProxySuspiciousConnectsModel {
       config.ldaPath,
       config.localUser,
       config.analysis,
-      config.nodes)
+      config.nodes,
+      config.ldaPRGSeed)
 
     new ProxySuspiciousConnectsModel(topicCount, documentResults, wordResults, timeCuts, entropyCuts, agentCuts)
   }

--- a/src/test/scala/org/opennetworkinsight/FlowWordCreationTest.scala
+++ b/src/test/scala/org/opennetworkinsight/FlowWordCreationTest.scala
@@ -21,13 +21,13 @@ class FlowWordCreationTest extends FlatSpec with Matchers {
     rowSrcIPLess(11) = "23"
 
     val result = FlowWordCreation.adjustPort(rowSrcIPLess(8), rowSrcIPLess(9), rowSrcIPLess(11).toInt, rowSrcIPLess(10).toInt,
-      rowSrcIPLess(29).toDouble, rowSrcIPLess(28).toDouble, rowSrcIPLess(30).toDouble)
+      rowSrcIPLess(29).toInt, rowSrcIPLess(28).toInt, rowSrcIPLess(30).toInt)
 
     result.length shouldBe 4
     result(1) shouldBe "10.0.2.115 172.16.0.107"
-    result(0) shouldBe "23.0"
-    result(3) shouldBe "-1_23.0_7.0_7.0_4.0"
-    result(2) shouldBe "23.0_7.0_7.0_4.0"
+    result(0) shouldBe "23"
+    result(3) shouldBe "-1_23_7_7_4"
+    result(2) shouldBe "23_7_7_4"
 
   }
 
@@ -37,28 +37,28 @@ class FlowWordCreationTest extends FlatSpec with Matchers {
     rowSrcIPLess(11) = "2132"
 
     val result = FlowWordCreation.adjustPort(rowSrcIPLess(8), rowSrcIPLess(9), rowSrcIPLess(11).toInt, rowSrcIPLess(10).toInt,
-      rowSrcIPLess(29).toDouble, rowSrcIPLess(28).toDouble, rowSrcIPLess(30).toDouble)
+      rowSrcIPLess(29).toInt, rowSrcIPLess(28).toInt, rowSrcIPLess(30).toInt)
 
     result.length shouldBe 4
     result(1) shouldBe "10.0.2.115 172.16.0.107"
-    result(0) shouldBe "23.0"
-    result(3) shouldBe "23.0_7.0_7.0_4.0"
-    result(2) shouldBe "-1_23.0_7.0_7.0_4.0"
+    result(0) shouldBe "23"
+    result(3) shouldBe "23_7_7_4"
+    result(2) shouldBe "-1_23_7_7_4"
   }
 
   // 3. Test when sip is less than dip and sip is not 0 and dport and sport are > 1024 +
-  it should "create word with ip_pair as sourceIp-destIp, port is 333333.0 and both words direction is 1 (not showing)" in {
+  it should "create word with ip_pair as sourceIp-destIp, port is 333333 and both words direction is 1 (not showing)" in {
     rowSrcIPLess(10) = "8392"
     rowSrcIPLess(11) = "9874"
 
     val result = FlowWordCreation.adjustPort(rowSrcIPLess(8), rowSrcIPLess(9), rowSrcIPLess(11).toInt, rowSrcIPLess(10).toInt,
-      rowSrcIPLess(29).toDouble, rowSrcIPLess(28).toDouble, rowSrcIPLess(30).toDouble)
+      rowSrcIPLess(29).toInt, rowSrcIPLess(28).toInt, rowSrcIPLess(30).toInt)
 
     result.length shouldBe 4
     result(1) shouldBe "10.0.2.115 172.16.0.107"
-    result(0) shouldBe "333333.0"
-    result(3) shouldBe "333333.0_7.0_7.0_4.0"
-    result(2) shouldBe "333333.0_7.0_7.0_4.0"
+    result(0) shouldBe "333333"
+    result(3) shouldBe "333333_7_7_4"
+    result(2) shouldBe "333333_7_7_4"
   }
 
   // 4. Test when sip is less than dip and sip is not 0 and dport is 0 but sport is not +
@@ -67,13 +67,13 @@ class FlowWordCreationTest extends FlatSpec with Matchers {
     rowSrcIPLess(11) = "0"
 
     val result = FlowWordCreation.adjustPort(rowSrcIPLess(8), rowSrcIPLess(9), rowSrcIPLess(11).toInt, rowSrcIPLess(10).toInt,
-      rowSrcIPLess(29).toDouble, rowSrcIPLess(28).toDouble, rowSrcIPLess(30).toDouble)
+      rowSrcIPLess(29).toInt, rowSrcIPLess(28).toInt, rowSrcIPLess(30).toInt)
 
     result.length shouldBe 4
     result(1) shouldBe "10.0.2.115 172.16.0.107"
-    result(0) shouldBe "80.0"
-    result(3) shouldBe "80.0_7.0_7.0_4.0"
-    result(2) shouldBe "-1_80.0_7.0_7.0_4.0"
+    result(0) shouldBe "80"
+    result(3) shouldBe "80_7_7_4"
+    result(2) shouldBe "-1_80_7_7_4"
   }
 
   // 5. Test when sip is less than dip and sip is not 0 and sport is 0 but dport is not +
@@ -82,28 +82,28 @@ class FlowWordCreationTest extends FlatSpec with Matchers {
     rowSrcIPLess(11) = "43"
 
     val result = FlowWordCreation.adjustPort(rowSrcIPLess(8), rowSrcIPLess(9), rowSrcIPLess(11).toInt, rowSrcIPLess(10).toInt,
-      rowSrcIPLess(29).toDouble, rowSrcIPLess(28).toDouble, rowSrcIPLess(30).toDouble)
+      rowSrcIPLess(29).toInt, rowSrcIPLess(28).toInt, rowSrcIPLess(30).toInt)
 
     result.length shouldBe 4
     result(1) shouldBe "10.0.2.115 172.16.0.107"
-    result(0) shouldBe "43.0"
-    result(3) shouldBe "-1_43.0_7.0_7.0_4.0"
-    result(2) shouldBe "43.0_7.0_7.0_4.0"
+    result(0) shouldBe "43"
+    result(3) shouldBe "-1_43_7_7_4"
+    result(2) shouldBe "43_7_7_4"
   }
 
   // 6. Test when sip is less than dip and sip is not 0 and sport and dport are less or equal than 1024 +
-  it should "create word with ip_pair as sourceIp-destIp, port is 111111.0 and both words direction is 1 (not showing)" in {
+  it should "create word with ip_pair as sourceIp-destIp, port is 111111 and both words direction is 1 (not showing)" in {
     rowSrcIPLess(10) = "1024"
     rowSrcIPLess(11) = "80"
 
     val result = FlowWordCreation.adjustPort(rowSrcIPLess(8), rowSrcIPLess(9), rowSrcIPLess(11).toInt, rowSrcIPLess(10).toInt,
-      rowSrcIPLess(29).toDouble, rowSrcIPLess(28).toDouble, rowSrcIPLess(30).toDouble)
+      rowSrcIPLess(29).toInt, rowSrcIPLess(28).toInt, rowSrcIPLess(30).toInt)
 
     result.length shouldBe 4
     result(1) shouldBe "10.0.2.115 172.16.0.107"
-    result(0) shouldBe "111111.0"
-    result(3) shouldBe "111111.0_7.0_7.0_4.0"
-    result(2) shouldBe "111111.0_7.0_7.0_4.0"
+    result(0) shouldBe "111111"
+    result(3) shouldBe "111111_7_7_4"
+    result(2) shouldBe "111111_7_7_4"
   }
 
   // 7. Test when sip is less than dip and sip is not 0 and sport and dport are 0+
@@ -112,13 +112,13 @@ class FlowWordCreationTest extends FlatSpec with Matchers {
     rowSrcIPLess(11) = "0"
 
     val result = FlowWordCreation.adjustPort(rowSrcIPLess(8), rowSrcIPLess(9), rowSrcIPLess(11).toInt, rowSrcIPLess(10).toInt,
-      rowSrcIPLess(29).toDouble, rowSrcIPLess(28).toDouble, rowSrcIPLess(30).toDouble)
+      rowSrcIPLess(29).toInt, rowSrcIPLess(28).toInt, rowSrcIPLess(30).toInt)
 
     result.length shouldBe 4
     result(1) shouldBe "10.0.2.115 172.16.0.107"
-    result(0) shouldBe "0.0"
-    result(3) shouldBe "0.0_7.0_7.0_4.0"
-    result(2) shouldBe "0.0_7.0_7.0_4.0"
+    result(0) shouldBe "0"
+    result(3) shouldBe "0_7_7_4"
+    result(2) shouldBe "0_7_7_4"
   }
 
   // 8. Test when sip is not less than dip and dport is <= 1024 & sport > 1024 and min(dport, sport) !=0+
@@ -127,13 +127,13 @@ class FlowWordCreationTest extends FlatSpec with Matchers {
     rowDstIPLess(11) = "43"
 
     val result = FlowWordCreation.adjustPort(rowDstIPLess(8), rowDstIPLess(9), rowDstIPLess(11).toInt, rowDstIPLess(10).toInt,
-      rowDstIPLess(29).toDouble, rowDstIPLess(28).toDouble, rowDstIPLess(30).toDouble)
+      rowDstIPLess(29).toInt, rowDstIPLess(28).toInt, rowDstIPLess(30).toInt)
 
     result.length shouldBe 4
     result(1) shouldBe "10.0.2.115 172.16.0.107"
-    result(0) shouldBe "43.0"
-    result(3) shouldBe "-1_43.0_7.0_7.0_4.0"
-    result(2) shouldBe "43.0_7.0_7.0_4.0"
+    result(0) shouldBe "43"
+    result(3) shouldBe "-1_43_7_7_4"
+    result(2) shouldBe "43_7_7_4"
 
   }
 
@@ -143,29 +143,29 @@ class FlowWordCreationTest extends FlatSpec with Matchers {
     rowDstIPLess(11) = "2435"
 
     val result = FlowWordCreation.adjustPort(rowDstIPLess(8), rowDstIPLess(9), rowDstIPLess(11).toInt, rowDstIPLess(10).toInt,
-      rowDstIPLess(29).toDouble, rowDstIPLess(28).toDouble, rowDstIPLess(30).toDouble)
+      rowDstIPLess(29).toInt, rowDstIPLess(28).toInt, rowDstIPLess(30).toInt)
 
     result.length shouldBe 4
     result(1) shouldBe "10.0.2.115 172.16.0.107"
-    result(0) shouldBe "80.0"
-    result(3) shouldBe "80.0_7.0_7.0_4.0"
-    result(2) shouldBe "-1_80.0_7.0_7.0_4.0"
+    result(0) shouldBe "80"
+    result(3) shouldBe "80_7_7_4"
+    result(2) shouldBe "-1_80_7_7_4"
 
   }
 
   // 10. Test when sip is not less than dip and dport and sport are > 1024 +
-  it should "create word with ip_pair as destIp-sourceIp, port is 333333.0 and both words direction is 1 (not showing)" in {
+  it should "create word with ip_pair as destIp-sourceIp, port is 333333 and both words direction is 1 (not showing)" in {
     rowDstIPLess(10) = "2354"
     rowDstIPLess(11) = "2435"
 
     val result = FlowWordCreation.adjustPort(rowDstIPLess(8), rowDstIPLess(9), rowDstIPLess(11).toInt, rowDstIPLess(10).toInt,
-      rowDstIPLess(29).toDouble, rowDstIPLess(28).toDouble, rowDstIPLess(30).toDouble)
+      rowDstIPLess(29).toInt, rowDstIPLess(28).toInt, rowDstIPLess(30).toInt)
 
     result.length shouldBe 4
     result(1) shouldBe "10.0.2.115 172.16.0.107"
-    result(0) shouldBe "333333.0"
-    result(3) shouldBe "333333.0_7.0_7.0_4.0"
-    result(2) shouldBe "333333.0_7.0_7.0_4.0"
+    result(0) shouldBe "333333"
+    result(3) shouldBe "333333_7_7_4"
+    result(2) shouldBe "333333_7_7_4"
   }
 
   // 11. Test when sip is not less than dip and dport is 0 but sport is not +
@@ -174,13 +174,13 @@ class FlowWordCreationTest extends FlatSpec with Matchers {
     rowDstIPLess(11) = "0"
 
     val result = FlowWordCreation.adjustPort(rowDstIPLess(8), rowDstIPLess(9), rowDstIPLess(11).toInt, rowDstIPLess(10).toInt,
-      rowDstIPLess(29).toDouble, rowDstIPLess(28).toDouble, rowDstIPLess(30).toDouble)
+      rowDstIPLess(29).toInt, rowDstIPLess(28).toInt, rowDstIPLess(30).toInt)
 
     result.length shouldBe 4
     result(1) shouldBe "10.0.2.115 172.16.0.107"
-    result(0) shouldBe "80.0"
-    result(3) shouldBe "80.0_7.0_7.0_4.0"
-    result(2) shouldBe "-1_80.0_7.0_7.0_4.0"
+    result(0) shouldBe "80"
+    result(3) shouldBe "80_7_7_4"
+    result(2) shouldBe "-1_80_7_7_4"
   }
 
   // 12. Test when sip is not less than dip and sport is 0 but dport is not +
@@ -189,28 +189,28 @@ class FlowWordCreationTest extends FlatSpec with Matchers {
     rowDstIPLess(11) = "2435"
 
     val result = FlowWordCreation.adjustPort(rowDstIPLess(8), rowDstIPLess(9), rowDstIPLess(11).toInt, rowDstIPLess(10).toInt,
-      rowDstIPLess(29).toDouble, rowDstIPLess(28).toDouble, rowDstIPLess(30).toDouble)
+      rowDstIPLess(29).toInt, rowDstIPLess(28).toInt, rowDstIPLess(30).toInt)
 
     result.length shouldBe 4
     result(1) shouldBe "10.0.2.115 172.16.0.107"
-    result(0) shouldBe "2435.0"
-    result(3) shouldBe "-1_2435.0_7.0_7.0_4.0"
-    result(2) shouldBe "2435.0_7.0_7.0_4.0"
+    result(0) shouldBe "2435"
+    result(3) shouldBe "-1_2435_7_7_4"
+    result(2) shouldBe "2435_7_7_4"
   }
 
   // 13. Test when sip is not less than dip and sport and dport are less or equal than 1024
-  it should "create word with ip_pair as destIp-sourceIp, port 111111.0 and both words direction is 1 (not showing)" in {
+  it should "create word with ip_pair as destIp-sourceIp, port 111111 and both words direction is 1 (not showing)" in {
     rowDstIPLess(10) = "80"
     rowDstIPLess(11) = "1024"
 
     val result = FlowWordCreation.adjustPort(rowDstIPLess(8), rowDstIPLess(9), rowDstIPLess(11).toInt, rowDstIPLess(10).toInt,
-      rowDstIPLess(29).toDouble, rowDstIPLess(28).toDouble, rowDstIPLess(30).toDouble)
+      rowDstIPLess(29).toInt, rowDstIPLess(28).toInt, rowDstIPLess(30).toInt)
 
     result.length shouldBe 4
     result(1) shouldBe "10.0.2.115 172.16.0.107"
-    result(0) shouldBe "111111.0"
-    result(3) shouldBe "111111.0_7.0_7.0_4.0"
-    result(2) shouldBe "111111.0_7.0_7.0_4.0"
+    result(0) shouldBe "111111"
+    result(3) shouldBe "111111_7_7_4"
+    result(2) shouldBe "111111_7_7_4"
   }
 
   // 14. Test when sip is not less than dip and sport and dport are 0
@@ -219,13 +219,13 @@ class FlowWordCreationTest extends FlatSpec with Matchers {
     rowDstIPLess(11) = "0"
 
     val result = FlowWordCreation.adjustPort(rowDstIPLess(8), rowDstIPLess(9), rowDstIPLess(11).toInt, rowDstIPLess(10).toInt,
-      rowDstIPLess(29).toDouble, rowDstIPLess(28).toDouble, rowDstIPLess(30).toDouble)
+      rowDstIPLess(29).toInt, rowDstIPLess(28).toInt, rowDstIPLess(30).toInt)
 
     result.length shouldBe 4
     result(1) shouldBe "10.0.2.115 172.16.0.107"
-    result(0) shouldBe "0.0"
-    result(3) shouldBe "0.0_7.0_7.0_4.0"
-    result(2) shouldBe "0.0_7.0_7.0_4.0"
+    result(0) shouldBe "0"
+    result(3) shouldBe "0_7_7_4"
+    result(2) shouldBe "0_7_7_4"
   }
 
 }


### PR DESCRIPTION
- SuspiciousConnects pipelines now have a CLI (unused by ml_ops at present) that can seed the PRG and make the runs deterministic for the purpose of testing
- for readability for users/debuggers:  netflow suspiciousconnects model "words" now use integers (not floats) so all the ".0" junk goes away...
  eg. -1_80.0_7.0_7.0_4.0  becomes -1_80_7_7_4

LINKED CHANGE TO ONI-LDA-C:
Open-Network-Insight/oni-lda-c#11
