### PR TITLE
Spark application logger.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.1"
 
 scalaVersion := "2.10.6"
 
-import sbtassembly.Plugin.AssemblyKeys._
+import AssemblyKeys._
 
 assemblySettings
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "1.1"
 
 scalaVersion := "2.10.6"
 
-import AssemblyKeys._
+import sbtassembly.Plugin.AssemblyKeys._
 
 assemblySettings
 
@@ -12,7 +12,6 @@ libraryDependencies += "org.apache.spark" %% "spark-core" % "1.6.0"
 libraryDependencies += "org.apache.spark" %% "spark-mllib" % "1.6.0"
 libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.6.0"
 libraryDependencies += "org.scalatest" % "scalatest_2.10" % "2.2.6"
-libraryDependencies += "org.slf4j" % "slf4j-api" % "1.7.10"
 libraryDependencies += "com.github.scopt" %% "scopt" % "3.5.0"
 
 resolvers += Resolver.sonatypeRepo("public")

--- a/src/main/scala/org/opennetworkinsight/SuspiciousConnects.scala
+++ b/src/main/scala/org/opennetworkinsight/SuspiciousConnects.scala
@@ -29,11 +29,11 @@ object SuspiciousConnects {
 
     val parser = SuspiciousConnectsArgumentParser.parser
 
+    val logger = LogManager.getLogger("SuspiciousConnectsAnalysis")
+    logger.setLevel(Level.INFO)
+
     parser.parse(args, SuspiciousConnectsConfig()) match {
       case Some(config) =>
-
-        val logger = LogManager.getLogger("SuspiciousConnectsAnalysis")
-        logger.setLevel(Level.INFO)
 
         Logger.getLogger("org").setLevel(Level.OFF)
         Logger.getLogger("akka").setLevel(Level.OFF)
@@ -48,12 +48,12 @@ object SuspiciousConnects {
           case "flow" => FlowSuspiciousConnects.run(config, sparkContext, sqlContext, logger)
           case "dns" => DNSSuspiciousConnects.run(config, sparkContext, sqlContext, logger)
           case "proxy" => ProxySuspiciousConnectsAnalysis.run(config, sparkContext, sqlContext, logger)
-          case _ => println("ERROR:  unsupported (or misspelled) analysis: " + analysis)
+          case _ => logger.error("Unsupported (or misspelled) analysis: " + analysis)
         }
 
         sparkContext.stop()
 
-      case None => println("Error parsing arguments")
+      case None => logger.error("Error parsing arguments")
     }
 
     System.exit(0)

--- a/src/main/scala/org/opennetworkinsight/SuspiciousConnects.scala
+++ b/src/main/scala/org/opennetworkinsight/SuspiciousConnects.scala
@@ -1,9 +1,8 @@
 package org.opennetworkinsight
 
-import org.apache.log4j.{Level, Logger}
-import org.apache.spark.{SparkConf, SparkContext}
+import org.apache.log4j.{Level, LogManager, Logger}
 import org.apache.spark.sql.SQLContext
-import org.slf4j.LoggerFactory
+import org.apache.spark.{SparkConf, SparkContext}
 import org.opennetworkinsight.SuspiciousConnectsArgumentParser.SuspiciousConnectsConfig
 import org.opennetworkinsight.dns.DNSSuspiciousConnects
 import org.opennetworkinsight.netflow.FlowSuspiciousConnects
@@ -32,7 +31,10 @@ object SuspiciousConnects {
 
     parser.parse(args, SuspiciousConnectsConfig()) match {
       case Some(config) =>
-        val logger = LoggerFactory.getLogger(this.getClass)
+
+        val logger = LogManager.getLogger("SuspiciousConnectsAnalysis")
+        logger.setLevel(Level.INFO)
+
         Logger.getLogger("org").setLevel(Level.OFF)
         Logger.getLogger("akka").setLevel(Level.OFF)
 

--- a/src/main/scala/org/opennetworkinsight/dns/DNSPostLDA.scala
+++ b/src/main/scala/org/opennetworkinsight/dns/DNSPostLDA.scala
@@ -1,12 +1,12 @@
 
 package org.opennetworkinsight.dns
 
+import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.opennetworkinsight.SuspiciousConnectsScoreFunction
 import org.opennetworkinsight.dns.DNSSchema._
-import org.slf4j.Logger
 
 /**
   * Contains routines for scoring incoming netflow records from a DNS suspicious connections model.

--- a/src/main/scala/org/opennetworkinsight/dns/DNSPreLDA.scala
+++ b/src/main/scala/org/opennetworkinsight/dns/DNSPreLDA.scala
@@ -100,7 +100,7 @@ object DNSPreLDA {
           QueryResponseCode)
     }
 
-    print("Read source data")
+    logger.info("Read source data")
     val totalDataDF = {
       if (!scoredFileExists) {
         rawData

--- a/src/main/scala/org/opennetworkinsight/dns/DNSPreLDA.scala
+++ b/src/main/scala/org/opennetworkinsight/dns/DNSPreLDA.scala
@@ -1,11 +1,11 @@
 package org.opennetworkinsight.dns
 
+import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.opennetworkinsight.OniLDACWrapper.OniLDACInput
 import org.opennetworkinsight.dns.DNSSchema._
-import org.slf4j.Logger
 
 import scala.io.Source
 

--- a/src/main/scala/org/opennetworkinsight/dns/DNSSuspiciousConnects.scala
+++ b/src/main/scala/org/opennetworkinsight/dns/DNSSuspiciousConnects.scala
@@ -1,11 +1,11 @@
 package org.opennetworkinsight.dns
 
+import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SQLContext
 import org.opennetworkinsight.OniLDACWrapper
 import org.opennetworkinsight.OniLDACWrapper.OniLDACOutput
 import org.opennetworkinsight.SuspiciousConnectsArgumentParser.SuspiciousConnectsConfig
-import org.slf4j.Logger
 
 object DNSSuspiciousConnects {
 

--- a/src/main/scala/org/opennetworkinsight/dns/DNSWordCreation.scala
+++ b/src/main/scala/org/opennetworkinsight/dns/DNSWordCreation.scala
@@ -1,5 +1,6 @@
 package org.opennetworkinsight.dns
 
+import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
@@ -8,7 +9,6 @@ import org.apache.spark.sql.types.{DoubleType, StringType, StructField, StructTy
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.opennetworkinsight.dns.{DNSSchema => Schema}
 import org.opennetworkinsight.utilities.{Entropy, Quantiles}
-import org.slf4j.Logger
 
 import scala.io.Source
 

--- a/src/main/scala/org/opennetworkinsight/netflow/FlowPostLDA.scala
+++ b/src/main/scala/org/opennetworkinsight/netflow/FlowPostLDA.scala
@@ -1,12 +1,12 @@
 package org.opennetworkinsight.netflow
 
+import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.opennetworkinsight.netflow.FlowSchema._
-import org.slf4j.Logger
 
 /**
   * Contains routines for scoring incoming netflow records from a netflow suspicious connections model.

--- a/src/main/scala/org/opennetworkinsight/netflow/FlowPreLDA.scala
+++ b/src/main/scala/org/opennetworkinsight/netflow/FlowPreLDA.scala
@@ -1,12 +1,12 @@
 
 package org.opennetworkinsight.netflow
 
+import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.opennetworkinsight.OniLDACWrapper.OniLDACInput
 import org.opennetworkinsight.netflow.FlowSchema._
-import org.slf4j.Logger
 
 import scala.io.Source
 

--- a/src/main/scala/org/opennetworkinsight/netflow/FlowSuspiciousConnects.scala
+++ b/src/main/scala/org/opennetworkinsight/netflow/FlowSuspiciousConnects.scala
@@ -1,11 +1,11 @@
 package org.opennetworkinsight.netflow
 
+import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SQLContext
 import org.opennetworkinsight.OniLDACWrapper
 import org.opennetworkinsight.OniLDACWrapper.OniLDACOutput
 import org.opennetworkinsight.SuspiciousConnectsArgumentParser.SuspiciousConnectsConfig
-import org.slf4j.Logger
 
 object FlowSuspiciousConnects {
 

--- a/src/main/scala/org/opennetworkinsight/netflow/FlowWordCreation.scala
+++ b/src/main/scala/org/opennetworkinsight/netflow/FlowWordCreation.scala
@@ -1,5 +1,6 @@
 package org.opennetworkinsight.netflow
 
+import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.functions._
@@ -7,7 +8,6 @@ import org.apache.spark.sql.types.{DoubleType, StringType, StructField, StructTy
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
 import org.opennetworkinsight.netflow.{FlowSchema => Schema}
 import org.opennetworkinsight.utilities.Quantiles
-import org.slf4j.Logger
 
 object FlowWordCreation {
 

--- a/src/main/scala/org/opennetworkinsight/proxy/ProxySuspiciousConnectsAnalysis.scala
+++ b/src/main/scala/org/opennetworkinsight/proxy/ProxySuspiciousConnectsAnalysis.scala
@@ -1,11 +1,11 @@
 package org.opennetworkinsight.proxy
 
+import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.SQLContext
 import org.opennetworkinsight.SuspiciousConnectsArgumentParser.SuspiciousConnectsConfig
 import org.opennetworkinsight.proxy.ProxySchema._
 import org.opennetworkinsight.utilities.DataFrameUtils
-import org.slf4j.Logger
 
 /**
   * Run suspicious connections analysis on proxy data.

--- a/src/main/scala/org/opennetworkinsight/proxy/ProxySuspiciousConnectsModel.scala
+++ b/src/main/scala/org/opennetworkinsight/proxy/ProxySuspiciousConnectsModel.scala
@@ -1,16 +1,16 @@
 package org.opennetworkinsight.proxy
 
+import org.apache.log4j.Logger
 import org.apache.spark.SparkContext
 import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{DataFrame, Row, SQLContext}
-import org.opennetworkinsight.{OniLDACWrapper, SuspiciousConnectsScoreFunction}
 import org.opennetworkinsight.OniLDACWrapper.{OniLDACInput, OniLDACOutput}
 import org.opennetworkinsight.SuspiciousConnectsArgumentParser.SuspiciousConnectsConfig
-import org.opennetworkinsight.utilities._
-import org.slf4j.Logger
 import org.opennetworkinsight.proxy.ProxySchema._
+import org.opennetworkinsight.utilities._
+import org.opennetworkinsight.{OniLDACWrapper, SuspiciousConnectsScoreFunction}
 
 /**
   * Encapsulation of a proxy suspicious connections model.


### PR DESCRIPTION
Aims to fix issue DB-520 Logger does not work in ML pipeline.
Users now are able to see what is going on with their oni-ml application.

![screen shot 2016-09-21 at 3 17 49 pm](https://cloud.githubusercontent.com/assets/17070509/18727520/a0d4d1c4-800e-11e6-80f0-91e7826d6a19.png)
