### PR TITLE
Parameterizing the topic count value

### DIFF
--- a/src/main/scala/org/opennetworkinsight/OniLDACWrapper.scala
+++ b/src/main/scala/org/opennetworkinsight/OniLDACWrapper.scala
@@ -108,7 +108,7 @@ object OniLDACWrapper {
     }
 
     // Create document results
-    val docToTopicMix = getDocumentResults(documentTopicMixRawLines, documentDictionary)
+    val docToTopicMix = getDocumentResults(documentTopicMixRawLines, documentDictionary, topicCount)
 
     // Create word results
     val wordResults = getWordToProbPerTopicMap(topicWordData, wordDictionary)
@@ -133,7 +133,7 @@ object OniLDACWrapper {
     wordProbs.map(_ / sumRawWord)
   }
 
-  def getTopicDocument(document: String, line: String) : (String, Array[Double])  = {
+  def getTopicDocument(document: String, line: String, topicCount: Int) : (String, Array[Double])  = {
     val topics = line.split(" ").map(_.toDouble)
     val topicsSum = topics.sum
 
@@ -142,7 +142,7 @@ object OniLDACWrapper {
       document -> topicsProb
     }
     else {
-      val topicsProb = Array.fill(20)(0d)
+      val topicsProb = Array.fill(topicCount)(0d)
       document ->  topicsProb
     }
   }
@@ -172,10 +172,11 @@ object OniLDACWrapper {
   }
 
   def getDocumentResults(topicDocumentData: Array[String],
-                         docIndexToDocument: Map[Int, String]) : Map[String, Array[Double]] = {
+                         docIndexToDocument: Map[Int, String],
+                         topicCount: Int) : Map[String, Array[Double]] = {
 
     topicDocumentData.zipWithIndex
-      .map({case (topic, docIdx) => getTopicDocument(docIndexToDocument(docIdx), topic)})
+      .map({case (topic, docIdx) => getTopicDocument(docIndexToDocument(docIdx), topic, topicCount)})
       .toMap
   }
 

--- a/src/main/scala/org/opennetworkinsight/netflow/FlowSuspiciousConnects.scala
+++ b/src/main/scala/org/opennetworkinsight/netflow/FlowSuspiciousConnects.scala
@@ -21,7 +21,7 @@ object FlowSuspiciousConnects {
       config.ldaPath, config.localUser,  config.analysis, config.nodes, config.ldaPRGSeed)
 
     FlowPostLDA.flowPostLDA(config.inputPath, config.hdfsScoredConnect, config.outputDelimiter, config.threshold, config.maxResults, documentResults,
-      wordResults, sparkContext, sqlContext, logger)
+      wordResults, config.topicCount, sparkContext, sqlContext, logger)
 
     logger.info("Flow LDA completed")
   }

--- a/src/main/scala/org/opennetworkinsight/proxy/ProxySuspiciousConnectsAnalysis.scala
+++ b/src/main/scala/org/opennetworkinsight/proxy/ProxySuspiciousConnectsAnalysis.scala
@@ -15,14 +15,12 @@ object ProxySuspiciousConnectsAnalysis {
   /**
     * Run suspicious connections analysis on proxy data.
     *
-    * @param config       SuspicionConnectsConfig objet, contains runtime parameters from CLI.
+    * @param config       SuspicionConnectsConfig object, contains runtime parameters from CLI.
     * @param sparkContext Apache Spark context.
     * @param sqlContext   Spark SQL context.
     * @param logger       Logs execution progress, information and errors for user.
     */
   def run(config: SuspiciousConnectsConfig, sparkContext: SparkContext, sqlContext: SQLContext, logger: Logger) = {
-
-    val topicCount = 20
 
     logger.info("Starting proxy suspicious connects analysis.")
 
@@ -35,7 +33,7 @@ object ProxySuspiciousConnectsAnalysis {
 
     logger.info("Training the model")
     val model =
-      ProxySuspiciousConnectsModel.trainNewModel(sparkContext, sqlContext, logger, config, rawDataDF, topicCount)
+      ProxySuspiciousConnectsModel.trainNewModel(sparkContext, sqlContext, logger, config, rawDataDF)
 
     logger.info("Scoring")
     val scoredDF = model.score(sparkContext, rawDataDF)

--- a/src/main/scala/org/opennetworkinsight/proxy/ProxySuspiciousConnectsModel.scala
+++ b/src/main/scala/org/opennetworkinsight/proxy/ProxySuspiciousConnectsModel.scala
@@ -86,15 +86,13 @@ object ProxySuspiciousConnectsModel {
     * @param config       SuspiciousConnetsArgumnetParser.Config object containg CLI arguments.
     * @param inDF           Dataframe for training data, with columns Host, Time, ReqMethod, FullURI, ResponseContentType,
     *                     UserAgent, RespCode (as defined in ProxySchema object).
-    * @param topicCount   Number of topics used for topic modelling during training.
     * @return ProxySuspiciousConnectsModel
     */
   def trainNewModel(sparkContext: SparkContext,
                     sqlContext: SQLContext,
                     logger: Logger,
                     config: SuspiciousConnectsConfig,
-                    inDF: DataFrame,
-                    topicCount: Int): ProxySuspiciousConnectsModel = {
+                    inDF: DataFrame): ProxySuspiciousConnectsModel = {
 
     logger.info("training new proxy suspcious connects model")
 
@@ -135,7 +133,7 @@ object ProxySuspiciousConnectsModel {
       config.nodes,
       config.ldaPRGSeed)
 
-    new ProxySuspiciousConnectsModel(topicCount, documentResults, wordResults, timeCuts, entropyCuts, agentCuts)
+    new ProxySuspiciousConnectsModel(config.topicCount, documentResults, wordResults, timeCuts, entropyCuts, agentCuts)
   }
 
   /**

--- a/src/test/scala/org/opennetworkinsight/OniLDACWrapperTest.scala
+++ b/src/test/scala/org/opennetworkinsight/OniLDACWrapperTest.scala
@@ -24,13 +24,13 @@ class OniLDACWrapperTest extends TestingSparkContextFlatSpec with Matchers{
 
   "getTopicDocument" should "return string of document and 20 values when the sum of each value in the line is bigger" +
     "than 0. Each result value should be divided by the sum of all values" in {
-
+    val topicCount = 20
     val document = "192.168.1.1"
     val line = "0.0124531442 0.0124531442 0.0124531442 0.0124531442 0.0124531442 0.0124531442 0.0124531442 0.0124531442 " +
       "0.0124531442 0.0124531442 0.0124531442 23983.5532262138 0.0124531442 0.0124531442 0.0124531442 0.0124531442 " +
       "0.0124531442 0.0124531442 22999.4716800747 0.0124531442"
 
-    var (docOUT, topicMixOUT) = OniLDACWrapper.getTopicDocument(document, line)
+    var (docOUT, topicMixOUT) = OniLDACWrapper.getTopicDocument(document, line, topicCount)
 
     docOUT shouldBe document
     topicMixOUT shouldBe Array(2.6505498126219955E-7, 2.6505498126219955E-7, 2.6505498126219955E-7, 2.6505498126219955E-7,
@@ -43,8 +43,8 @@ class OniLDACWrapperTest extends TestingSparkContextFlatSpec with Matchers{
   it should "return string of document and 0.0 20 times when the sum of each value in the line is 0" in {
     val document = "192.168.1.1"
     val line = "0.0 0.0 1.0 -1.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0 0.0"
-
-    val (docOUT, topicMixOUT) = OniLDACWrapper.getTopicDocument(document, line)
+    val topicCount = 20
+    val (docOUT, topicMixOUT) = OniLDACWrapper.getTopicDocument(document, line, topicCount)
 
     docOUT shouldBe document
     topicMixOUT shouldBe Array(0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
@@ -77,7 +77,7 @@ class OniLDACWrapperTest extends TestingSparkContextFlatSpec with Matchers{
   "getDocumentResults" should "return Array[String] of documents and its 20 values when the sum of each value in the line is bigger" +
     "than 0. Each result value should be divided by the sum of all values and the result array order should be the same" +
     "as incomming data (topicDocument Data)" in {
-
+    val topicCount = 20
     val documentDictionary = Map(3 -> "10.10.98.123", 0 -> "66.23.45.11", 1 -> "192.168.1.1", 2 -> "133.546.43.22")
     val topicDocumentData = Array("0.0124531442 0.0124531442 0.0124531442 0.0124531442 0.0124531442 0.0124531442 0.0124531442 " +
       "0.0124531442 0.0124531442 0.0124531442 0.0124531442 23983.5532262138 0.0124531442 0.0124531442 0.0124531442 " +
@@ -92,7 +92,7 @@ class OniLDACWrapperTest extends TestingSparkContextFlatSpec with Matchers{
       "0.0124531442 0.0124531442 0.0124531442 0.0124531442 0.0124531442 0.0124531442 0.0124531442 12.0124531442 " +
       "0.0124531442 0.0124531442 0.0124531442 0.0124531442")
 
-    val results = OniLDACWrapper.getDocumentResults(topicDocumentData, documentDictionary)
+    val results = OniLDACWrapper.getDocumentResults(topicDocumentData, documentDictionary, topicCount)
 
     results("66.23.45.11") shouldBe Array(2.6505498126219955E-7, 2.6505498126219955E-7, 2.6505498126219955E-7, 2.6505498126219955E-7,
       2.6505498126219955E-7, 2.6505498126219955E-7, 2.6505498126219955E-7, 2.6505498126219955E-7, 2.6505498126219955E-7,


### PR DESCRIPTION
Added code to pass along the topic count input from the command line so that it is used consistently throughout the flow. 

Also updated wrapper tests to provide appropriate input args (since topic count was added to some functions).
